### PR TITLE
Add "\r\n" on SendSq to make it works with some ZTE firmwares

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-go@v4
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v6.0.0
         with:
           distribution: goreleaser
           version: latest

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # zteOnu
+
+This is a fork from original [project](https://github.com/Septrum101/zteOnu)
+
 Type `./zteonu -h` for help
+
+# What's different from original one
+
+- Added all known user/password combinations in a loop; the binary will attempt all of them to enable Telnet.
+- Added the --seclvl parameter (default: 2) to change the Telnet access level and avoid the "Access Denied" error.
+- Added firewall configuration when enabling permanent Telnet access.
+- Removed login retries to prevent account lock-out.
+- Changed to use the default HTTP port 80 instead of 8080.

--- a/app/factory/fac_test.go
+++ b/app/factory/fac_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/thank243/zteOnu/utils"
+	"github.com/stich86/zteOnu/utils"
 )
 
 func TestNewDev(t *testing.T) {

--- a/app/factory/factory.go
+++ b/app/factory/factory.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/go-resty/resty/v2"
 
-	"github.com/thank243/zteOnu/utils"
+	"github.com/stich86/zteOnu/utils"
 )
 
 func New(user string, passwd string, ip string, port int) *Factory {

--- a/app/factory/factory.go
+++ b/app/factory/factory.go
@@ -190,7 +190,7 @@ func (f *Factory) handle() (tlUser string, tlPass string, err error) {
 		fmt.Println("ok")
 	}
 
-	fmt.Print("step [3] check login auth: ")
+	fmt.Print("step [3] check login auth with user: ")
 	switch ver {
 	case 1:
 		if err = f.checkLoginAuth(); err != nil {
@@ -219,23 +219,32 @@ func (f *Factory) handle() (tlUser string, tlPass string, err error) {
 	return
 }
 
-func (f *Factory) Handle() (tlUser string, tlPass string, err error) {
-	count := 0
-	for {
-		tlUser, tlPass, err = f.handle()
-		if err != nil {
-			count++
-			if count > 10 {
-				return
-			}
-			fmt.Println(err, fmt.Sprintf("Attempt retrying..(%d/10)", count))
-			time.Sleep(time.Millisecond * 500)
-			continue
-		}
-		break
-	}
+//func (f *Factory) Handle() (tlUser string, tlPass string, err error) {
+//	count := 0
+//	for {
+//		tlUser, tlPass, err = f.handle()
+//		if err != nil {
+//			count++
+//			if count > 5 {
+//				return
+//			}
+//			fmt.Println(err, fmt.Sprintf("Attempt retrying..(%d/5)", count))
+//			time.Sleep(time.Millisecond * 500)
+//			continue
+//		}
+//		break
+//	}
+//
+//	return
+//}
 
-	return
+func (f *Factory) Handle() (tlUser string, tlPass string, err error) {
+    // Prova una singola combinazione e ritorna immediatamente
+    tlUser, tlPass, err = f.handle()
+    if err != nil {
+        return "", "", err // Ritorna l'errore se la combinazione non ha funzionato
+    }
+    return tlUser, tlPass, nil // Ritorna le credenziali se ha avuto successo
 }
 
 func getKeyPool(version uint8, r int, newR int) []byte {

--- a/app/factory/factory.go
+++ b/app/factory/factory.go
@@ -56,7 +56,7 @@ func (f *Factory) sendSq() (uint8, error) {
 	var version uint8
 
 	r := time.Now().Second()
-	resp, err := f.cli.R().SetBody(fmt.Sprintf("SendSq.gch?rand=%d", r)).Post("webFac")
+	resp, err := f.cli.R().SetBody(fmt.Sprintf("SendSq.gch?rand=%d\r\n", r)).Post("webFac")
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/app/telnet/telnet.go
+++ b/app/telnet/telnet.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"strconv"
 )
 
 func New(user string, pass string, ip string, port int) (*Telnet, error) {
@@ -21,12 +22,12 @@ func New(user string, pass string, ip string, port int) (*Telnet, error) {
 	return t, nil
 }
 
-func (t *Telnet) PermTelnet() error {
+func (t *Telnet) PermTelnet(SecLvl int) error {
 	if err := t.loginTelnet(); err != nil {
 		return err
 	}
 
-	if err := t.modifyDB(); err != nil {
+	if err := t.modifyDB(SecLvl); err != nil {
 		return err
 	}
 
@@ -41,14 +42,14 @@ func (t *Telnet) loginTelnet() error {
 	return t.sendCmd(t.user, t.pass)
 }
 
-func (t *Telnet) modifyDB() error {
+func (t *Telnet) modifyDB(SecLvl int) error {
 	// set DB data
 	prefix := "sendcmd 1 DB set TelnetCfg 0 "
 	lanEnable := prefix + "Lan_Enable 1"
 	tsLanUser := prefix + "TSLan_UName root"
 	tsLanPwd := prefix + "TSLan_UPwd Zte521"
 	maxConn := prefix + "Max_Con_Num 3"
-	initSecLvl := prefix + "InitSecLvl 2"
+	initSecLvl := prefix + "InitSecLvl " + strconv.Itoa(SecLvl)
 
 	// save DB
 	save := "sendcmd 1 DB save"

--- a/app/telnet/telnet.go
+++ b/app/telnet/telnet.go
@@ -30,6 +30,10 @@ func (t *Telnet) PermTelnet() error {
 		return err
 	}
 
+	if err := t.modifyFW(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -44,12 +48,32 @@ func (t *Telnet) modifyDB() error {
 	tsLanUser := prefix + "TSLan_UName root"
 	tsLanPwd := prefix + "TSLan_UPwd Zte521"
 	maxConn := prefix + "Max_Con_Num 3"
-	initSecLvl := prefix + "InitSecLvl 3"
+	initSecLvl := prefix + "InitSecLvl 2"
 
 	// save DB
 	save := "sendcmd 1 DB save"
 
 	if err := t.sendCmd(lanEnable, tsLanUser, tsLanPwd, maxConn, initSecLvl, save); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *Telnet) modifyFW() error {
+	// set DB data
+	prefix := "sendcmd 1 DB addr FWSC 0"
+	viewName := prefix + "ViewName IGD.FWSc.FWSC1"
+	enable := prefix + "Enable 1"
+	intName := prefix + "INCName LAN"
+	intViewName := prefix + "INCViewName IGD.LD1"
+	service := prefix + "Servise 8"
+	filter := prefix + "FilterTarget 1"
+
+	// save DB
+	save := "sendcmd 1 DB save"
+
+	if err := t.sendCmd(prefix, viewName, enable, intName, intViewName, service, filter, save); err != nil {
 		return err
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,7 +38,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&user, "user", "u", "telecomadmin", "factory mode auth username")
 	rootCmd.PersistentFlags().StringVarP(&passwd, "pass", "p", "nE7jA%5m", "factory mode auth password")
 	rootCmd.PersistentFlags().StringVarP(&ip, "ip", "i", "192.168.1.1", "ONU ip address")
-	rootCmd.PersistentFlags().IntVar(&port, "port", 8080, "ONU http port")
+	rootCmd.PersistentFlags().IntVar(&port, "port", 80, "ONU http port")
 	rootCmd.PersistentFlags().BoolVar(&permTelnet, "telnet", false, "permanent telnet (user: root, pass: Zte521)")
 	rootCmd.PersistentFlags().IntVar(&telnetPort, "tp", 23, "ONU telnet port")
 	rootCmd.PersistentFlags().BoolVar(&newMode, "new", false, "use new method to open telnet, MAC address must set to 00:07:29:55:35:57")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/thank243/zteOnu/version"
+	"github.com/stich86/zteOnu/version"
 )
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/thank243/zteOnu
+module github.com/stich86/zteOnu
 
 go 1.22.0
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"github.com/thank243/zteOnu/cmd"
+	"github.com/stich86/zteOnu/cmd"
 )
 
 func main() {

--- a/version/version.go
+++ b/version/version.go
@@ -5,10 +5,10 @@ import (
 )
 
 var (
-	version = "dev"
+	version = "0.0.7"
 	appName = "ZteONU"
-	date    = "unknown"
-	intro   = "https://github.com/thank243/zteOnu"
+	date    = "09/10/2024"
+	intro   = "https://github.com/stich86/zteOnu"
 )
 
 func Show() {


### PR DESCRIPTION
Hi @Septrum101,

i was able to open telnet on ZTE F6005v3 with firmware 3.0.10N06 that has the MAC-Address check enabled, but it needs a slight modification on the SendSq function. The string should be sent with a carrige return and new line, otherwise the `httpd` daemon doesn't extract the number from the `rand ` variable

This fix also open telnet with old method on the same ONT with lower firmware that doesn't have new MAC-Address check.

Just a question: do you have reversed the magicByte function? It will be nice if we know how to generate it and avoid to change it

Thanks in advance!